### PR TITLE
develop/BT-111 : BoongTam-server develop 카카오톡에 로그인 정보 비교요청 배제

### DIFF
--- a/src/controllers/mypageController.js
+++ b/src/controllers/mypageController.js
@@ -13,10 +13,13 @@ export const getUserInfo = async (req, res) => {
 
 	try {
 		// 카카오 API에서 사용자 ID 가져오기
-		const userid = await fetchUserFromKakao(token)
+		// const userid = await fetchUserFromKakao(token)
 
 		// DB에서 사용자 정보 가져오기
-		const userInfo = await mypageService.getUserInfo(userid)
+		// const userInfo = await mypageService.getUserInfo(userid)
+
+        // DB에서 사용자 정보 가져오기 (토큰 비교)
+        const userInfo = await mypageService.getUserByToken(token);
 
         res.status(200).json({
             code: 200,
@@ -71,20 +74,41 @@ export const updateUserInfo = async (req, res) => {
 
     try {
         // 카카오 API에서 사용자 ID 가져오기
-        const userid = await fetchUserFromKakao(token);
+        // const userid = await fetchUserFromKakao(token);
 
         // DB에서 기존 데이터 확인 (null 값 처리)
-        const existingUserInfo = await mypageService.getUserInfo(userid);
+        // const existingUserInfo = await mypageService.getUserInfo(userid);
+
+        const userInfo = await mypageService.getUserByToken(token);
+
+        if (!userInfo) {
+            return res.status(401).json({
+                ...errorCode[401],
+                detail: "유효하지 않은 토큰입니다.",
+            });
+        }
+
+        const userid = userInfo.user_id; // 사용자 ID 가져오기
 
         let updatedUser;
+        /*
+        // kakao 인증 시 필요한 코드
         if (existingUserInfo[type] === null || existingUserInfo[type] === undefined) {
             // 값이 없으면 INSERT (새 값 추가)
             updatedUser = await mypageService.insertUserInfo(userid, type, value);
         } else {
             // 값이 있으면 UPDATE (기존 값 수정)
             updatedUser = await mypageService.updateUserInfo(userid, type, value);
-        }
+        }*/
 
+        if (userInfo[type] === null || userInfo[type] === undefined) {
+            // 값이 없으면 INSERT (새 값 추가)
+            updatedUser = await mypageService.insertUserInfo(userid, type, value);
+        } else {
+            // 값이 있으면 UPDATE (기존 값 수정)
+            updatedUser = await mypageService.updateUserInfo(userid, type, value);
+        }
+        
         // 바뀐 정보를 응답 본문에 추가
         res.status(200).json({
             code: 200,

--- a/src/models/mypageModel.js
+++ b/src/models/mypageModel.js
@@ -11,6 +11,15 @@ export const getUserInfo = async (userid) => {
     return result[0];
 }
 
+// 1.5 사용자 토큰으로 정보 조회
+export const getUserByToken = async (token) => {
+    const query = 'SELECT id AS user_id, nickname, profile_picture, points FROM users WHERE token = ?';
+    const connection = await getDB();
+    const [result] = await connection.execute(query, [token]);
+    return result.length ? result[0] : null;
+};
+
+
 // 2. 사용자 정보 수정
 export const updateUserInfo = async (userid, type, value) => {
     const query = `UPDATE users SET ${type} = ? WHERE id = ?`;

--- a/src/models/storeModel.js
+++ b/src/models/storeModel.js
@@ -13,7 +13,7 @@ export const getStoreDetails = async (storeid) => {
         s.is_order_online,
         s.latitude, s.longitude,
         sd.*
-    FROM Stores s
+    FROM stores s # 소문자  
     JOIN store_details sd ON s.store_id = sd.store_id
     WHERE s.store_id = ?;
 `;
@@ -33,7 +33,7 @@ export const getStoreDetails = async (storeid) => {
 
 // 매장 메뉴 정보 조회
 export const getStoreMenu = async (storeid) => {
-    const query = 'SELECT * FROM Menu WHERE store_id = ?';
+    const query = 'SELECT * FROM menu WHERE store_id = ?';
     const connection = await getDB();
     //const result2 = await connection.execute(query, [storeid]);
     const rows = await connection.execute(query, [storeid]);
@@ -45,7 +45,7 @@ export const getStoreMenu = async (storeid) => {
 
 // 매장 사진 정보 조회
 export const getStorePhotos = async (storeid, filter) => {
-	let query = 'SELECT * FROM Photos WHERE store_id = ?'
+	let query = 'SELECT * FROM photos WHERE store_id = ?'
 	const params = [storeid]
 
 	if (filter) {
@@ -70,7 +70,7 @@ export const getStoreReviews = async (storeid, sort) => {
             sr.*,
             u.nickname
         FROM 
-            Store_reviews sr
+            store_reviews sr
         JOIN 
             users u
         ON 

--- a/src/services/boongService.js
+++ b/src/services/boongService.js
@@ -23,7 +23,7 @@ export const fetchNearbyStores = async (
                     COS(RADIANS(?)) * COS(RADIANS(latitude)) * COS(RADIANS(longitude) - RADIANS(?)) + 
                     SIN(RADIANS(?)) * SIN(RADIANS(latitude))
                 )) AS distance
-            FROM Stores
+            FROM stores # 소문자로 해야 클라우드 db 실행됨
             WHERE 
                 latitude BETWEEN ? AND ? AND 
                 longitude BETWEEN ? AND ?

--- a/src/services/mypageService.js
+++ b/src/services/mypageService.js
@@ -24,6 +24,11 @@ export const getUserInfo = async (userId) => {
     return await mypageModel.getUserInfo(userId);
 };
 
+// DB에서 토큰으로 사용자 정보 가져오기
+export const getUserByToken = async (token) => {
+    return await mypageModel.getUserByToken(token);
+};
+
 // 사용자 정보 수정
 export const updateUserInfo = async (userId, type, value) => {
     try {


### PR DESCRIPTION
1. [브랜치주소](https://algoflow.atlassian.net/browse/KAN-111)

2. 내용 요약:

- 원래는 카카오 api를 불러와 토큰값을 비교하였는데, 이게 현재로는 테스트가 불가능
- 새로운 함수 getUserByToken를 활용하여 헤더의 토큰값과, db의 토큰값만을 비교

3. 팀원에게 할 말
- [api표](https://algoflow.atlassian.net/wiki/spaces/FBQGL/database/7897121?atl_f=PAGETREE)에
기능 테스트 후 체크하기
- 쿼리 오류 나면 select * from (테이블 이름) 에서 테이블 이름 소문자로 바꿔보세요
