### PR TITLE
Develop/BT-132: [server] 커뮤니티 - 굿즈 및 매장 리뷰 보기 기능 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,17 @@ ADD COLUMN `modified_date` TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CU
 
 ALTER TABLE `store_reviews`
 ADD COLUMN `modified_date` TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+
+5. 리뷰에 누르는 하트 테이블 추가
+CREATE TABLE `review_likes` (
+    `like_id` INT NOT NULL AUTO_INCREMENT,
+    `review_type` ENUM('goods', 'store') NOT NULL, -- 리뷰 유형을 구분
+    `review_id` INT NOT NULL, -- 리뷰 ID (goods_review_id 또는 store_review_id)
+    `user_id` BIGINT NOT NULL,
+    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`like_id`),
+    UNIQUE KEY `unique_user_review` (`review_type`, `review_id`, `user_id`), -- 중복 방지
+    KEY `review_id` (`review_id`),
+    KEY `user_id` (`user_id`),
+    CONSTRAINT `review_likes_ibfk_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ authUtil 및 다른 model에 errorcode 통합 적용
 AWS 클라우드 DB로 연동
 메인, 맵 API 대폭 수정
 
+### 1월 7일
+커뮤니티-매장 및 굿즈 리뷰 보기 (인기순, 최신순으로 개수 지정해 나열 가능) api 추가
+
 > sql 수정 사항
 1. CREATE TABLE `photos` (
     `photo_id` int NOT NULL AUTO_INCREMENT,

--- a/src/controllers/communityReviewController.js
+++ b/src/controllers/communityReviewController.js
@@ -76,3 +76,35 @@ export const createGoodsReview = async (req, res) => {
         res.status(error.code || 500).json({ code: error.code || 500, message:error.message, detail: error.detail || '상품 리뷰 작성 중 오류가 발생했습니다.' });
     }
 };
+
+// 굿즈 리뷰 조회
+export const getGoodsReviews = async (req, res) => {
+    const token = req.headers.authorization;  // 토큰을 요청 헤더에서 추출
+
+    // 토큰이 없을 경우 오류 응답
+    if (!token) {
+        return res.status(400).json({ ...errorCode[400], detail: '토큰값을 확인해주세요.' });
+    }
+    const userId = await testvalidateTokenAndUser(token);
+    console.log(userId); // 필요한 경우 로그 출력
+    
+    const { sort = 'latest', count = 5 } = req.query;
+
+    try {
+        const reviews = await communityReviewService.getGoodsReviews(sort, count);
+        res.status(200).json({
+            code: 200,
+            msg: '리뷰 조회 성공',
+            count: reviews.length,
+            data: reviews,
+        });
+    } catch (error) {
+        console.error('리뷰 조회 오류:', error.message);
+        // res.status(500).json({
+        //     code: 500,
+        //     message: '리뷰 조회 중 서버 오류가 발생했습니다.',
+        //     detail: error.message,
+        // });
+        res.status(error.code || 500).json({ code: error.code || 500, message:error.message, detail: error.detail || '상품 리뷰 작성 중 오류가 발생했습니다.' });
+    }
+};

--- a/src/controllers/communityReviewController.js
+++ b/src/controllers/communityReviewController.js
@@ -2,6 +2,7 @@ import * as communityReviewService from '../services/communityReviewService.js';
 import testvalidateTokenAndUser from '../util/authUtils.js'
 import errorCode from '../util/error.js'
 
+// 매장 리뷰 작성
 export const createStoreReview = async (req, res) => {
     const token = req.headers.authorization;
     const { store_id, review_text, review_rating, review_photos } = req.body;
@@ -38,7 +39,7 @@ export const createStoreReview = async (req, res) => {
     }
 };
 
-
+// 굿즈 리뷰 작성
 export const createGoodsReview = async (req, res) => {
     const token = req.headers.authorization;
     const { goods_id, review_text, review_rating, review_photos } = req.body;
@@ -77,6 +78,33 @@ export const createGoodsReview = async (req, res) => {
     }
 };
 
+// 매장 리뷰 조회
+export const getStoreReviews = async (req, res) => {
+    const token = req.headers.authorization;  // 토큰을 요청 헤더에서 추출
+
+    // 토큰이 없을 경우 오류 응답
+    if (!token) {
+        return res.status(400).json({ ...errorCode[400], detail: '토큰값을 확인해주세요.' });
+    }
+    const userId = await testvalidateTokenAndUser(token);
+    console.log(userId); // 필요한 경우 로그 출력
+
+    const { sort = 'latest', count = 5 } = req.query;
+
+    try {
+        const reviews = await communityReviewService.getStoreReviews(sort, count);
+        res.status(200).json({
+            code: 200,
+            msg: '리뷰 조회 성공',
+            count: reviews.length,
+            data: reviews,
+        });
+    } catch (error) {
+        console.error('리뷰 조회 오류:', error.message);
+        res.status(error.code || 500).json({ code: error.code || 500, message:error.message, detail: error.detail || '매장 리뷰 조회 중 오류가 발생했습니다.' });
+    }
+};
+
 // 굿즈 리뷰 조회
 export const getGoodsReviews = async (req, res) => {
     const token = req.headers.authorization;  // 토큰을 요청 헤더에서 추출
@@ -87,7 +115,7 @@ export const getGoodsReviews = async (req, res) => {
     }
     const userId = await testvalidateTokenAndUser(token);
     console.log(userId); // 필요한 경우 로그 출력
-    
+
     const { sort = 'latest', count = 5 } = req.query;
 
     try {
@@ -100,11 +128,7 @@ export const getGoodsReviews = async (req, res) => {
         });
     } catch (error) {
         console.error('리뷰 조회 오류:', error.message);
-        // res.status(500).json({
-        //     code: 500,
-        //     message: '리뷰 조회 중 서버 오류가 발생했습니다.',
-        //     detail: error.message,
-        // });
-        res.status(error.code || 500).json({ code: error.code || 500, message:error.message, detail: error.detail || '상품 리뷰 작성 중 오류가 발생했습니다.' });
+        res.status(error.code || 500).json({ code: error.code || 500, message:error.message, detail: error.detail || '굿즈 리뷰 조회 중 오류가 발생했습니다.' });
     }
 };
+    

--- a/src/models/communityReviewModel.js
+++ b/src/models/communityReviewModel.js
@@ -71,3 +71,45 @@ export const findGoodsReviews = async (sort = 'latest', count = 5) => {
         },
     }));
 };
+
+// 매장 리뷰 조회
+export const findStoreReviews = async (sort = 'latest', count = 5) => {
+    const sortColumn = sort === 'popular' ? 'like_count' : 'sr.review_date';
+    const query = `
+        SELECT 
+            sr.store_review_id, 
+            sr.store_id,
+            sr.review_rating,
+            sr.review_text, 
+            SUBSTRING_INDEX(sr.store_review_photo_url, ',', 1) AS review_first_image_url,
+            sr.review_date,
+            u.id AS user_id,
+            u.nickname,
+            u.profile_picture,
+            COUNT(rl.like_id) AS like_count
+        FROM store_reviews sr
+        JOIN users u ON sr.user_id = u.id
+        LEFT JOIN review_likes rl 
+            ON rl.review_type = 'store' AND rl.review_id = sr.store_review_id
+        GROUP BY sr.store_review_id
+        ORDER BY ${sortColumn} DESC
+        LIMIT ?
+    `;
+
+    const connection = await getDB();
+    const [rows] = await connection.execute(query, [count]);
+    return rows.map(row => ({
+        store_review_id: row.store_review_id,
+        store_id: row.store_id,
+        review_text: row.review_text,
+        review_rating: row.review_rating,
+        review_first_image_url: row.review_first_image_url,
+        review_date: row.review_date,
+        like_count: row.like_count, // 하트 개수 추가
+        user_simple_info: {
+            user_id: row.user_id,
+            nickname: row.nickname,
+            profile_picture: row.profile_picture,
+        },
+    }));
+};

--- a/src/routes/communityRoutes.js
+++ b/src/routes/communityRoutes.js
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { createStoreReview, createGoodsReview, getGoodsReviews } from '../controllers/communityReviewController.js';
+import { createStoreReview, createGoodsReview, getStoreReviews, getGoodsReviews } from '../controllers/communityReviewController.js';
 
 const router = Router()
 
@@ -9,6 +9,10 @@ router.post('/store/review', createStoreReview)
 // 굿즈 리뷰 작성
 router.post('/goods/review', createGoodsReview)
 
+// 매장 리뷰 조회
+router.get('/sre', getStoreReviews);
+
 // 굿즈 리뷰 조회
-router.get('/goods/reviews', getGoodsReviews);
+router.get('/gre', getGoodsReviews);
+
 export default router

--- a/src/routes/communityRoutes.js
+++ b/src/routes/communityRoutes.js
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { createStoreReview, createGoodsReview } from '../controllers/communityReviewController.js';
+import { createStoreReview, createGoodsReview, getGoodsReviews } from '../controllers/communityReviewController.js';
 
 const router = Router()
 
@@ -9,5 +9,6 @@ router.post('/store/review', createStoreReview)
 // 굿즈 리뷰 작성
 router.post('/goods/review', createGoodsReview)
 
-
+// 굿즈 리뷰 조회
+router.get('/goods/reviews', getGoodsReviews);
 export default router

--- a/src/services/communityReviewService.js
+++ b/src/services/communityReviewService.js
@@ -18,3 +18,11 @@ export const getGoodsReviews = async (sort, count) => {
         throw new Error('리뷰 데이터를 가져오는 데 실패했습니다: ' + error.message);
     }
 };
+
+export const getStoreReviews= async (sort, count) => {
+    try {
+        return await communityReviewModel.findStoreReviews(sort, count);
+    } catch (error) {
+        throw new Error('리뷰 데이터를 가져오는 데 실패했습니다: ' + error.message);
+    }
+};

--- a/src/services/communityReviewService.js
+++ b/src/services/communityReviewService.js
@@ -1,12 +1,20 @@
 import * as communityReviewModel from '../models/communityReviewModel.js';
 
+// 매장 리뷰 작성
 export const createStoreReview = async (storeId, userId, reviewText, reviewRating, reviewPhotos) => {
     return await communityReviewModel.createStoreReview(storeId, userId, reviewText, reviewRating, reviewPhotos);
 };
 
+// 굿즈 리뷰 작성
 export const createGoodsReview = async (goodsId, userId, reviewText, reviewRating, reviewPhotos) => {
     return await communityReviewModel.createGoodsReview(goodsId, userId, reviewText, reviewRating, reviewPhotos);
 };
 
-// 다른 상품 리뷰 관련 서비스 로직 (조회, 수정 등)
-
+// 리뷰 조회
+export const getGoodsReviews = async (sort, count) => {
+    try {
+        return await communityReviewModel.findGoodsReviews(sort, count);
+    } catch (error) {
+        throw new Error('리뷰 데이터를 가져오는 데 실패했습니다: ' + error.message);
+    }
+};


### PR DESCRIPTION
1. [브랜치 주소](https://algoflow.atlassian.net/browse/KAN-132)
2. 내용요약
[매장 리뷰 리스트 api 명세서](https://algoflow.atlassian.net/wiki/x/KIB4)
[굿즈 리뷰 리스트 api 명세서](https://algoflow.atlassian.net/wiki/x/AYB6)

커뮤니티의 기능 중 굿즈 및 매장 리뷰를 조회할 수 있는 api를 만들었습니다
param 중 sort로 최신순(기본), 인기순(하트많은 순)으로 정렬할 수 있고, count로 나열할 개수를 지정할 수 있습니다.
두 api 다 authorization 토큰이 필요합니다

![image](https://github.com/user-attachments/assets/c1a48314-b142-4285-870b-d0b2c1c240c3)
{{base}}community/gre?sort=popular&count=3
![image](https://github.com/user-attachments/assets/33761ea5-684e-445e-b08d-020b1496229f)
{{base}}community/sre?sort=latest&count=5

3. 팀원에게 할 말
- 리뷰에 대한 하트를 누르는 review_likes 테이블이 새로 생겼습니다(원래 있던건 리뷰에 대한 댓글 테이블)
- 다음에 만들 api는 커뮤니티의 하트 토글 api 입니다