### PR TITLE
Develop bt 135: [server] 리뷰 좋아요 (하트) 토글 기능 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,29 @@ ADD COLUMN `modified_date` TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CU
 
 ALTER TABLE `store_reviews`
 ADD COLUMN `modified_date` TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+
+
+7. 리뷰 좋아요 테이블 분리
+- 데이터 무결성을 위해 매장 리뷰 좋아요 테이블과 굿즈 리뷰 좋아요 테이블로 분리
+
+CREATE TABLE `store_review_likes` (
+    `like_id` INT(11) NOT NULL AUTO_INCREMENT,
+    `store_review_id` INT(11) NOT NULL,
+    `user_id` BIGINT(20) NOT NULL,
+    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+    PRIMARY KEY (`like_id`),
+    UNIQUE KEY `unique_user_review` (`store_review_id`, `user_id`),
+    FOREIGN KEY (`store_review_id`) REFERENCES `store_reviews` (`store_review_id`) ON DELETE CASCADE,
+    FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `goods_review_likes` (
+    `like_id` INT(11) NOT NULL AUTO_INCREMENT,
+    `goods_review_id` INT(11) NOT NULL,
+    `user_id` BIGINT(20) NOT NULL,
+    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+    PRIMARY KEY (`like_id`),
+    UNIQUE KEY `unique_user_review` (`goods_review_id`, `user_id`),
+    FOREIGN KEY (`goods_review_id`) REFERENCES `goods_reviews` (`goods_review_id`) ON DELETE CASCADE,
+    FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ authUtil 및 다른 model에 errorcode 통합 적용
 AWS 클라우드 DB로 연동
 메인, 맵 API 대폭 수정
 
+### 1월 8일
+리뷰에 대한 좋아요 (하트) 토글 기능 추가 - 머지 후 라우터 조금 더 손봐야 함
+
 > sql 수정 사항
 1. CREATE TABLE `photos` (
     `photo_id` int NOT NULL AUTO_INCREMENT,

--- a/src/controllers/reviewLikeController.js
+++ b/src/controllers/reviewLikeController.js
@@ -1,0 +1,33 @@
+import { ReviewLikeService as Service } from '../services/reviewLikeService.js';
+import testvalidateTokenAndUser from '../util/authUtils.js'
+import errorCode from '../util/error.js'
+
+
+export const ReviewLikeController = {
+    updateLikeStatus: async (req, res) => {
+        const token = req.headers.authorization 
+        if (!token) {
+            return res.status(401).json(errorCode[401]); // errorCode 적용
+        }
+        const userId = await testvalidateTokenAndUser(token)
+		console.log(userId)
+        
+        const { review_type: reviewType, review_id: reviewId, like } = req.body;
+        
+    
+        try {
+          await Service.updateLikeStatus({ reviewType, reviewId, like, userId });
+    
+          return res.status(200).json({
+            code: 200,
+            message: 'Review like status updated successfully.',
+          });
+        } catch (error) {
+          console.error(error.message);
+          return res.status(400).json({
+            ...errorCode[400],
+            detail: 'Failed to update review like status.',
+          });
+        }
+      },
+    };

--- a/src/models/reviewLikeModel.js
+++ b/src/models/reviewLikeModel.js
@@ -1,0 +1,50 @@
+import { getDB } from '../database/connection.js';
+
+export const ReviewLikeModel = {
+  addLike: async (reviewType, reviewId, userId) => {
+    let tableName, reviewColumn;
+    
+    if (reviewType === 'store') {
+      tableName = 'store_review_likes';
+      reviewColumn = 'store_review_id';
+    } else if (reviewType === 'goods') {
+      tableName = 'goods_review_likes';
+      reviewColumn = 'goods_review_id';
+    } else {
+      throw new Error('Invalid review type');
+    }
+
+    const query = `
+      INSERT INTO ${tableName} (${reviewColumn}, user_id)
+      VALUES (?, ?)
+      ON DUPLICATE KEY UPDATE ${reviewColumn} = ${reviewColumn};
+    `;
+
+    const connection = await getDB();
+    const result = await connection.execute(query, [reviewId, userId]);
+    return result;
+  },
+
+  removeLike: async (reviewType, reviewId, userId) => {
+    let tableName, reviewColumn;
+    
+    if (reviewType === 'store') {
+      tableName = 'store_review_likes';
+      reviewColumn = 'store_review_id';
+    } else if (reviewType === 'goods') {
+      tableName = 'goods_review_likes';
+      reviewColumn = 'goods_review_id';
+    } else {
+      throw new Error('Invalid review type');
+    }
+
+    const query = `
+      DELETE FROM ${tableName}
+      WHERE ${reviewColumn} = ? AND user_id = ?;
+    `;
+    
+    const connection = await getDB();
+    const result = await connection.execute(query, [reviewId, userId]);
+    return result;
+  },
+};

--- a/src/routes/communityRoutes.js
+++ b/src/routes/communityRoutes.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { createStoreReview, createGoodsReview } from '../controllers/communityReviewController.js';
+import { ReviewLikeController } from '../controllers/reviewLikeController.js'
 
 const router = Router()
 
@@ -9,5 +10,7 @@ router.post('/store/review', createStoreReview)
 // 굿즈 리뷰 작성
 router.post('/goods/review', createGoodsReview)
 
+// 하트 토글
+router.patch('/re/like', ReviewLikeController.updateLikeStatus);
 
 export default router

--- a/src/services/reviewLikeService.js
+++ b/src/services/reviewLikeService.js
@@ -1,0 +1,17 @@
+import { ReviewLikeModel as ReviewModel} from '../models/reviewLikeModel.js';
+
+export const ReviewLikeService = {
+    updateLikeStatus: async ({ reviewType, reviewId, like, userId }) => {
+      if (!['store', 'goods'].includes(reviewType)) {
+        throw new Error('Invalid review type');
+      }
+  
+      if (like) {
+        // 하트 추가
+        await ReviewModel.addLike(reviewType, reviewId, userId);
+      } else {
+        // 하트 취소
+        await ReviewModel.removeLike(reviewType, reviewId, userId);
+      }
+    },
+  };


### PR DESCRIPTION
1. [브랜치 주소](https://algoflow.atlassian.net/browse/KAN-135)
2. 내용 요약 및 [api 명세서](https://algoflow.atlassian.net/wiki/x/bIB2)
![image](https://github.com/user-attachments/assets/3c81ed1d-695c-430e-8c88-6198e60efda4)

```
{
    "review_type":"goods",
    "review_id":1,
    "like": true
}
```
를 바디로 보내면 좋아요 테이블에 데이터가 들어갑니다. 반대로 false이면 데이터가 삭제됩니다.
누가 눌렀는지 식별하기 위해 헤더에 authorization 토큰을 받습니다

매장 리뷰에 대한 좋아요와 굿즈 리뷰에 대한 좋아요 테이블이 원래 통합해 하나였는데 따로 관리하는 게 좋을 거 같아 테이블을 나눴습니다.

3. 팀원에게 남길말
- 프론트 쪽에서 빈하트를 누르면 true, 채워진 하트를 누르면(하트 취소)를 누르면 false를 전송하는 쪽으로 짜면 될 거 같습니다.

- 이전 코드 머지가 늦어져서 커뮤니티 쪽 라우터 통합해서 손봐야 됨